### PR TITLE
Add quiet/timeout parameters and return remote command errno

### DIFF
--- a/src/ratp-barebox-cli/ratp-barebox-cli.c
+++ b/src/ratp-barebox-cli/ratp-barebox-cli.c
@@ -179,7 +179,7 @@ run_command (ratp_link_t *ratp,
     if ((st = ratp_link_close_sync (ratp, 1000)) != RATP_STATUS_OK)
         fprintf (stderr, "warning: couldn't close link: %s\n", ratp_status_str (st));
 
-    return 0;
+    return errno_result;
 }
 
 static int


### PR DESCRIPTION
These patches add mroe parameters:
-q to use quiet mode, which means nothing mroe than the command value will be returned.
-T to set a specific timeout for commands
finally, the command execution return the errno from the remote barebox.