### PR TITLE
Fix compile warnings in run_i2c_read

### DIFF
--- a/src/ratp-barebox-cli/ratp-barebox-cli.c
+++ b/src/ratp-barebox-cli/ratp-barebox-cli.c
@@ -530,6 +530,7 @@ run_i2c_read (ratp_link_t  *ratp,
 
     if (aux2[0] == '\0') {
         reg = 0;
+        reglen = 2;
         flags |= RATP_BAREBOX_LINK_I2C_FLAG_MASTER_MODE;
     } else {
         if (strncmp (aux2, "0x", 2) == 0)
@@ -647,6 +648,7 @@ run_i2c_write (ratp_link_t  *ratp,
 
     if (aux2[0] == '\0') {
         reg = 0;
+        reglen = 2;
         flags |= RATP_BAREBOX_LINK_I2C_FLAG_MASTER_MODE;
     } else {
         if (strncmp (aux2, "0x", 2) == 0)

--- a/src/ratp-barebox-cli/ratp-barebox-cli.c
+++ b/src/ratp-barebox-cli/ratp-barebox-cli.c
@@ -541,7 +541,7 @@ run_i2c_read (ratp_link_t  *ratp,
             goto out;
         }
         reg = strtoul (aux2, NULL, 16);
-        assert (reglen <= 0xFFFF);
+        assert (reg <= 0xFFFF);
         if (reglen == 4)
             flags |= RATP_BAREBOX_LINK_I2C_FLAG_WIDE_ADDRESS;
     }
@@ -659,7 +659,7 @@ run_i2c_write (ratp_link_t  *ratp,
             goto out;
         }
         reg = strtoul (aux2, NULL, 16);
-        assert (reglen <= 0xFFFF);
+        assert (reg <= 0xFFFF);
         if (reglen == 4)
             flags |= RATP_BAREBOX_LINK_I2C_FLAG_WIDE_ADDRESS;
     }


### PR DESCRIPTION
when compiling ratp-barebox-cli I encountered the following warning/error message:
```
ratp-barebox-cli.c:682:16: error: ‘reglen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         printf ("Sending i2c-write request: bus:0x%02x addr:0x%02x reg:0x%0*x (+%zu bytes)\n",
                ^
ratp-barebox-cli.c:605:20: note: ‘reglen’ was declared here
     int            reglen;
                    ^
ratp-barebox-cli.c:560:16: error: ‘reglen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         printf ("Sending i2c-read request: bus:0x%02x addr:0x%02x reg:0x%0*x (+%lu bytes)\n",
                ^
ratp-barebox-cli.c:488:20: note: ‘reglen’ was declared here
     int            reglen;
                    ^
```

After a quick look at `run_i2c_read`, the `reglen` variable can indeed be used uninitialized, I also noticed a typo in the assert when parsing the `reg` value. See commit messages for more details.

Thanks